### PR TITLE
Fixing base uri

### DIFF
--- a/app/config/config.ini
+++ b/app/config/config.ini
@@ -10,7 +10,7 @@ modelsDir      = /../app/models/
 viewsDir       = /../app/views/
 pluginsDir     = /../app/plugins/
 libraryDir     = /../app/library/
-baseUri        = /invo/
+baseUri        = /
 
 [metadata]
 adapter = "Apc"


### PR DESCRIPTION
With it being set to /invo/ the assets are loaded not from the root but from /invo/css/ and /invo/js, which breaks it.