### PR TITLE
Changed findFirstById() to findFirst()

### DIFF
--- a/app/controllers/ProducttypesController.php
+++ b/app/controllers/ProducttypesController.php
@@ -61,7 +61,7 @@ class ProductTypesController extends ControllerBase
         $request = $this->request;
         if (!$request->isPost()) {
 
-            $producttypes = ProductTypes::findFirstById(array('id=:id:', 'bind' => array('id' => $id)));
+            $producttypes = ProductTypes::findFirst(array('id=:id:', 'bind' => array('id' => $id)));
             if (!$producttypes) {
                 $this->flash->error("Product type to edit was not found");
                 return $this->forward("producttypes/index");


### PR DESCRIPTION
I installed this demo today using Phalcon 1.3.2 to find the Edit Product Type feature does not function. When clicking the Edit Product Type button I was receiving a "array to string conversion" notice on line 64 and the "Product type to edit was not found" error message.

Upon viewing other controllers, it seems that other edit functions such as that on the ProductsController use Model::findFirst() as opposed to Model::findFirstById().

Please correct me if I'm wrong, as this is my first try at Phalcon... but my little change corrected the error for me.

---

Changed ProductTypes:findFirstById() to ProductTypes::findFirst() in ProducttypesController.
