### PR TITLE
Fix wrong length of password column in createdb.php

### DIFF
--- a/schemas/createdb.php
+++ b/schemas/createdb.php
@@ -185,8 +185,8 @@ try {
 					'notNull' => TRUE,
 				]),
 				new Column("password", [
-					'type' => Column::TYPE_VARCHAR,
-					'size' => 30,
+					'type' => Column::TYPE_CHAR,
+					'size' => 40,
 					'notNull' => TRUE,
 				]),
 				new Column("name", [


### PR DESCRIPTION
SHA-1 hashes are 40 characters long, but createdb.php set the password column to 30.
