### PR TITLE
Remove Numericality from From Validation

### DIFF
--- a/app/forms/ProductsForm.php
+++ b/app/forms/ProductsForm.php
@@ -6,7 +6,7 @@ use Phalcon\Forms\Element\Hidden;
 use Phalcon\Forms\Element\Select;
 use Phalcon\Validation\Validator\PresenceOf;
 use Phalcon\Validation\Validator\Email;
-use Phalcon\Validation\Validator\Numericality;
+use Phalcon\Mvc\Model\Validator\Numericality;
 
 class ProductsForm extends Form
 {

--- a/app/forms/ProductsForm.php
+++ b/app/forms/ProductsForm.php
@@ -6,7 +6,6 @@ use Phalcon\Forms\Element\Hidden;
 use Phalcon\Forms\Element\Select;
 use Phalcon\Validation\Validator\PresenceOf;
 use Phalcon\Validation\Validator\Email;
-use Phalcon\Mvc\Model\Validator\Numericality;
 
 class ProductsForm extends Form
 {
@@ -50,9 +49,6 @@ class ProductsForm extends Form
             new PresenceOf(array(
                 'message' => 'Price is required'
             )),
-            new Numericality(array(
-                'message' => 'Price is required'
-            ))
         ));
         $this->add($price);
     }


### PR DESCRIPTION
I'm using v1.3.4 and the Numericality class does not exist at Phalcon\Validation\Validator\Numericality.