### PR TITLE
Added the 401 error page to the guest allowed ACL.

### DIFF
--- a/app/plugins/SecurityPlugin.php
+++ b/app/plugins/SecurityPlugin.php
@@ -57,7 +57,7 @@ class SecurityPlugin extends Plugin
 				'index'      => array('index'),
 				'about'      => array('index'),
 				'register'   => array('index'),
-				'errors'     => array('show404', 'show500'),
+				'errors'     => array('show401', 'show404', 'show500'),
 				'session'    => array('index', 'register', 'start', 'end'),
 				'contact'    => array('index', 'send')
 			);
@@ -115,6 +115,7 @@ class SecurityPlugin extends Plugin
 				'controller' => 'errors',
 				'action'     => 'show401'
 			));
+                        $this->session->destroy();
 			return false;
 		}
 	}


### PR DESCRIPTION
Added the 401 error page to guest allowed in ACL.
Added a session->destroy to SecurityPlugin error exit path to force reload of ACL, and generally clean up if there is a authorization error.  Without the 401 page added to the ACL the $dispatcher->forward was getting an unauthorized page and the dispatcher was going into a loop that returned nothing when Phalcon forces the dispatcher to exit