### PR TITLE
[BUGFIX] Remove unused view inclusion

### DIFF
--- a/app/controllers/ProductsController.php
+++ b/app/controllers/ProductsController.php
@@ -56,7 +56,6 @@ class ProductsController extends ControllerBase
         ));
 
         $this->view->page = $paginator->getPaginate();
-        $this->view->products = $products;
     }
 
     /**


### PR DESCRIPTION
The "$this->view->products" which was set in the controller is not used in the template.