### PR TITLE
Change the SecurityPlugin attached event to beforeExecuteRoute - services.php

### DIFF
--- a/app/config/services.php
+++ b/app/config/services.php
@@ -25,7 +25,7 @@ $di->set('dispatcher', function () use ($di) {
 	/**
 	 * Check if the user is allowed to access certain action using the SecurityPlugin
 	 */
-	$eventsManager->attach('dispatch:beforeDispatch', new SecurityPlugin);
+	$eventsManager->attach('dispatch:beforeExecuteRoute', new SecurityPlugin);
 
 	/**
 	 * Handle exceptions and not-found exceptions using NotFoundPlugin

--- a/app/plugins/SecurityPlugin.php
+++ b/app/plugins/SecurityPlugin.php
@@ -94,7 +94,7 @@ class SecurityPlugin extends Plugin
 	 * @param Event $event
 	 * @param Dispatcher $dispatcher
 	 */
-	public function beforeDispatch(Event $event, Dispatcher $dispatcher)
+	public function beforeExecuteRoute(Event $event, Dispatcher $dispatcher)
 	{
 
 		$auth = $this->session->get('auth');


### PR DESCRIPTION
NotFoundPlugin for handling the '404 not found' does not get chance to fire as beforeDispatch event fired before beforeException.

Change the "SecurityPlugin" attached event to "beforeExecuteRoute" from "beforeDispatch" should solve the problem.
