### PR TITLE
Fixed NotFoundPlugin::beforeException

### DIFF
--- a/app/plugins/NotFoundPlugin.php
+++ b/app/plugins/NotFoundPlugin.php
@@ -19,10 +19,10 @@ class NotFoundPlugin extends Plugin
 	 *
 	 * @param Event $event
 	 * @param MvcDispatcher $dispatcher
-	 * @param Exception $exception
+	 * @param \Exception $exception
 	 * @return boolean
 	 */
-	public function beforeException(Event $event, MvcDispatcher $dispatcher, Exception $exception)
+	public function beforeException(Event $event, MvcDispatcher $dispatcher, \Exception $exception)
 	{
 		error_log($exception->getMessage() . PHP_EOL . $exception->getTraceAsString());
 
@@ -30,18 +30,23 @@ class NotFoundPlugin extends Plugin
 			switch ($exception->getCode()) {
 				case Dispatcher::EXCEPTION_HANDLER_NOT_FOUND:
 				case Dispatcher::EXCEPTION_ACTION_NOT_FOUND:
-					$dispatcher->forward(array(
-						'controller' => 'errors',
-						'action' => 'show404'
-					));
+					$dispatcher->forward(
+						[
+							'controller' => 'errors',
+							'action'     => 'show404'
+						]
+					);
 					return false;
 			}
 		}
 
-		$dispatcher->forward(array(
-			'controller' => 'errors',
-			'action'     => 'show500'
-		));
+		$dispatcher->forward(
+			[
+				'controller' => 'errors',
+				'action'     => 'show500'
+			]
+		);
+
 		return false;
 	}
 }


### PR DESCRIPTION
Argument 3 passed to `NotFoundPlugin::beforeException` must be an instance of `\Exception`

How to reproduce:
1. Disable `SecurityPlugin`:
   
   ``` php
   // $eventsManager->attach('dispatch:beforeDispatch', new SecurityPlugin);
   ```
2. Try to get not existing resource
   
   ``` sh
   $ curl -X GET invo.local/not-found-resource-here | \
       grep Catchable | \
       sed -e 's/\(<tr>.\+<\/span>\)\(.*\)\(<i>\)\([0-9]*\)\(.*\)/\2 \4/g'
   ```

Output:

```
Catchable fatal error: Argument 3 passed to
PhalconDemo\Plugins\NotFoundPlugin::beforeException() must be an instance of 
PhalconDemo\Plugins\Exception, instance of Phalcon\Mvc\Dispatcher\Exception
given in .../app/plugins/NotFoundPlugin.php on line  26
```
