### PR TITLE
Fixed validation in Users model for Phalcon 3.

### DIFF
--- a/app/models/Users.php
+++ b/app/models/Users.php
@@ -1,26 +1,32 @@
 <?php
 
 use Phalcon\Mvc\Model;
-use Phalcon\Mvc\Model\Validator\Email as EmailValidator;
-use Phalcon\Mvc\Model\Validator\Uniqueness as UniquenessValidator;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Email as EmailValidator;
+use Phalcon\Validation\Validator\Uniqueness as UniquenessValidator;
 
 class Users extends Model
 {
     public function validation()
     {
-        $this->validate(new EmailValidator(array(
-            'field' => 'email'
-        )));
-        $this->validate(new UniquenessValidator(array(
-            'field' => 'email',
+        $validator = new Validation();
+        
+        $validator->add(
+            'email',
+            new EmailValidator([
+            'message' => 'Invalid email given'
+        ]));
+        $validator->add(
+            'email',
+            new UniquenessValidator([
             'message' => 'Sorry, The email was registered by another user'
-        )));
-        $this->validate(new UniquenessValidator(array(
-            'field' => 'username',
+        ]));
+        $validator->add(
+            'username',
+            new UniquenessValidator([
             'message' => 'Sorry, That username is already taken'
-        )));
-        if ($this->validationHasFailed() == true) {
-            return false;
-        }
+        ]));
+        
+        return $this->validate($validator);
     }
 }


### PR DESCRIPTION
Previously a sign-up attempt gave the error

Catchable fatal error: Argument 1 passed to
Phalcon\Mvc\Model::validate() must implement interface
Phalcon\ValidationInterface, instance of
Phalcon\Mvc\Model\Validator\Email given in
C:\wamp64\www\invo\app\models\Users.php on line 13

The validation has been altered to work in Phalcon 3.
(Phalcon\Mvc\Model\Validator has been deprecated in favour of Phalcon\Validation\Validator since they did similar things, according to the accepted answer to this question
http://stackoverflow.com/questions/39000827/phalcon-3-validating-form-data-using-phalcon-mvc-model-validator ).