### PR TITLE
Update SessionController.php

### DIFF
--- a/app/controllers/SessionController.php
+++ b/app/controllers/SessionController.php
@@ -16,7 +16,7 @@ class SessionController extends ControllerBase
     public function indexAction()
     {
         if (!$this->request->isPost()) {
-            $this->tag->setDefault('email', 'demo@phalconphp.com');
+            $this->tag->setDefault('email', 'demo');
             $this->tag->setDefault('password', 'phalcon');
         }
     }


### PR DESCRIPTION
This is a kind of counter-intuitive change, but the field is named "email" but the system actually treats it as a username when it looks it up in the database. Kind of a dirty quick fix for now. Perhaps somebody can go around and rename all instances of `$_POST['email']` to `$_POST['username']` etc.