### PR TITLE
Fix migration column timestamp type size error

### DIFF
--- a/db/migrations/1.0.0/contact.php
+++ b/db/migrations/1.0.0/contact.php
@@ -61,7 +61,7 @@ class ContactMigration_100 extends Migration
                         'created_at',
                         [
                             'type' => Column::TYPE_TIMESTAMP,
-                            'default' => "CURRENT_TIMESTAMP",
+                            'default' => "CURRENT_TIMESTAMP(1)",
                             'notNull' => true,
                             'size' => 1,
                             'after' => 'comments'

--- a/db/migrations/1.0.0/users.php
+++ b/db/migrations/1.0.0/users.php
@@ -70,7 +70,7 @@ class UsersMigration_100 extends Migration
                         'created_at',
                         [
                             'type' => Column::TYPE_TIMESTAMP,
-                            'default' => "CURRENT_TIMESTAMP",
+                            'default' => "CURRENT_TIMESTAMP(1)",
                             'notNull' => true,
                             'size' => 1,
                             'after' => 'email'


### PR DESCRIPTION
Fix #94 

Ref:
https://coderedirect.com/questions/432184/mysql-invalid-default-value-for-timestamp